### PR TITLE
Add 500k and 1M row options to benchmarks page

### DIFF
--- a/landing/src/components/BenchmarkRunner.tsx
+++ b/landing/src/components/BenchmarkRunner.tsx
@@ -175,8 +175,8 @@ const SCHEMA: ColumnSchema[] = [
   { name: 'volume', type: 'number' },
 ];
 
-const ROW_COUNTS = [10000, 50000, 100000];
-const ROW_LABELS = ['10k', '50k', '100k'];
+const ROW_COUNTS = [10000, 50000, 100000, 500000, 1000000];
+const ROW_LABELS = ['10k', '50k', '100k', '500k', '1M'];
 const FRAME_BUDGET_MS = 16;
 
 export function BenchmarkRunner() {


### PR DESCRIPTION
## Summary
- Extends benchmark row count options from 10k/50k/100k to include 500k and 1M
- Allows users to test grid performance at larger scales (up to 1 million rows)
- Helps demonstrate the grid's performance claims

## Test plan
- [ ] Navigate to /benchmarks page
- [ ] Verify slider shows 5 options: 10k, 50k, 100k, 500k, 1M
- [ ] Run benchmark with 500k and 1M rows to confirm functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)