### PR TITLE
Add 'Built in Tampa' to footer

### DIFF
--- a/landing/src/components/CTA.astro
+++ b/landing/src/components/CTA.astro
@@ -45,7 +45,7 @@
       </div>
     </div>
     <div class="mt-8 text-center text-grid-muted text-sm">
-      MIT License • © 2024 AskTurret
+      MIT License • © 2026 AskTurret • Built in Tampa
     </div>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
Adds "Built in Tampa" to the landing page footer, matching askturret.com branding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)