### PR TITLE
Add greyscale US flag icon to footer

### DIFF
--- a/landing/src/components/CTA.astro
+++ b/landing/src/components/CTA.astro
@@ -44,8 +44,38 @@
         </a>
       </div>
     </div>
-    <div class="mt-8 text-center text-grid-muted text-sm">
-      MIT License • © 2026 AskTurret • Built in Tampa
+    <div class="mt-8 flex flex-col items-center gap-3 text-sm text-grid-muted">
+      <p>MIT License • © 2026 AskTurret</p>
+      <div class="flex items-center justify-center gap-2 opacity-70">
+        <svg class="h-4 w-6 opacity-60" viewBox="0 0 24 16" fill="currentColor" aria-hidden="true">
+          <!-- Stars field -->
+          <rect x="0" y="0" width="10" height="8" fill="currentColor" opacity="0.8"/>
+          <!-- Stripes -->
+          <rect x="10" y="0" width="14" height="1.23" fill="currentColor" opacity="0.7"/>
+          <rect x="10" y="2.46" width="14" height="1.23" fill="currentColor" opacity="0.7"/>
+          <rect x="10" y="4.92" width="14" height="1.23" fill="currentColor" opacity="0.7"/>
+          <rect x="10" y="7.38" width="14" height="1.23" fill="currentColor" opacity="0.7"/>
+          <rect x="0" y="8" width="24" height="1.23" fill="currentColor" opacity="0.7"/>
+          <rect x="0" y="10.46" width="24" height="1.23" fill="currentColor" opacity="0.7"/>
+          <rect x="0" y="12.92" width="24" height="1.23" fill="currentColor" opacity="0.7"/>
+          <!-- Stars (simplified) -->
+          <circle cx="2" cy="1.5" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="4" cy="1.5" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="6" cy="1.5" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="8" cy="1.5" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="3" cy="3" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="5" cy="3" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="7" cy="3" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="2" cy="4.5" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="4" cy="4.5" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="6" cy="4.5" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="8" cy="4.5" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="3" cy="6" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="5" cy="6" r="0.5" fill="currentColor" opacity="0.3"/>
+          <circle cx="7" cy="6" r="0.5" fill="currentColor" opacity="0.3"/>
+        </svg>
+        <span>Built in Tampa, FL</span>
+      </div>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
## Summary
Adds greyscale US flag SVG icon next to "Built in Tampa" text in footer, matching noranshine.vercel.app styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)