### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners for @askturret/grid
+# These users will be automatically requested for review on PRs
+
+# Default owner for everything
+* @alprimak


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` file
- Set @alprimak as default owner for all files
- PRs will now automatically request review from codeowner

## Test plan
- [x] CODEOWNERS file created with correct syntax
- [ ] Verify automatic review request on future PRs

🤖 Generated with [Claude Code](https://claude.ai/code)