### PR TITLE
Fix broken documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A high-performance React data grid that lets you pick the right engine for your workload. Three battle-tested architectures, one simple API.
 
-[Live Demo](https://grid.askturret.com/demo/) · [Documentation](https://alprimak.github.io/askturret-grid/) · [Benchmarks](https://grid.askturret.com/benchmarks/)
+[Live Demo](https://grid.askturret.com/demo/) · [Documentation](https://grid.askturret.com/getting-started/installation/) · [Benchmarks](https://grid.askturret.com/benchmarks/)
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix documentation link pointing to defunct GitHub Pages URL
- Update to consolidated docs on landing site: `grid.askturret.com/getting-started/installation/`

## Test plan
- [x] Old link returns 404: `alprimak.github.io/askturret-grid/`
- [x] New link works: `grid.askturret.com/getting-started/installation/`

🤖 Generated with [Claude Code](https://claude.ai/code)