### PR TITLE
Add PostHog analytics for landing site

### DIFF
--- a/landing/src/components/BenchmarkRunner.tsx
+++ b/landing/src/components/BenchmarkRunner.tsx
@@ -224,6 +224,14 @@ export function BenchmarkRunner() {
     setError(null);
     setProgress('Generating test data...');
 
+    // Track benchmark start in PostHog
+    if (typeof window !== 'undefined' && (window as any).posthog) {
+      (window as any).posthog.capture('benchmark_started', {
+        pattern,
+        row_count: rowCount,
+      });
+    }
+
     await new Promise((r) => setTimeout(r, 50));
 
     try {
@@ -421,6 +429,20 @@ export function BenchmarkRunner() {
         winnerLatency,
         winnerThroughput,
       });
+
+      // Track benchmark completion in PostHog
+      if (typeof window !== 'undefined' && (window as any).posthog) {
+        (window as any).posthog.capture('benchmark_completed', {
+          pattern,
+          row_count: rowCount,
+          winner_latency: winnerLatency,
+          winner_throughput: winnerThroughput,
+          avg_latency_js: avgLatencyJs,
+          avg_latency_wasm: avgLatencyWasm,
+          avg_latency_worker: avgLatencyWorker,
+        });
+      }
+
       setProgress('');
     } catch (e) {
       console.error('Benchmark error:', e);

--- a/landing/src/layouts/Base.astro
+++ b/landing/src/layouts/Base.astro
@@ -38,6 +38,17 @@ const {
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>{title}</title>
 
+    <!-- PostHog Analytics -->
+    <script>
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace('.i.','.') + "/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId setPersonProperties".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+      posthog.init('phc_w7xoF0LeguMRhzIijzWk6qc80PeWEPss8QSGTZrNDjT', {
+        api_host: 'https://us.i.posthog.com',
+        person_profiles: 'identified_only',
+        capture_pageview: true,
+        capture_pageleave: true
+      });
+    </script>
+
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- Add PostHog script to `Base.astro` layout (all pages)
- Track custom events in benchmark runner:
  - `benchmark_started` - when user clicks Run
  - `benchmark_completed` - with results and winners

## Events tracked

**Pageviews** (automatic):
- All pages on grid.askturret.com

**Custom events**:
| Event | Properties |
|-------|------------|
| `benchmark_started` | pattern, row_count |
| `benchmark_completed` | pattern, row_count, winner_latency, winner_throughput, avg_latency_* |

## PostHog project
Key: `phc_w7xoF0LeguMRhzIijzWk6qc80PeWEPss8QSGTZrNDjT`

## Test plan
- [x] PostHog script added to head
- [x] Events fire on benchmark start/complete
- [ ] Verify events appear in PostHog dashboard after deploy

🤖 Generated with [Claude Code](https://claude.ai/code)